### PR TITLE
simpler access to metadata via observatory.cartodb.com

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,4 +16,4 @@ to the test Observatory account.
 
 Run automated tests against a hostname:
 
-    (venv) OBS_HOSTNAME=<hostname.cartodb.com> OBS_API_KEY=foobar OBS_META_HOSTNAME=<meta hostname> OBS_META_API_KEY=<meta api_key> nosetests scripts/autotest.py
+    (venv) OBS_HOSTNAME=<hostname.cartodb.com> OBS_API_KEY=<api_key> OBS_META_HOSTNAME=observatory.cartodb.com OBS_META_API_KEY= nosetests scripts/autotest.py

--- a/scripts/autotest.py
+++ b/scripts/autotest.py
@@ -25,19 +25,19 @@ def query(q, is_meta=False, **options):
     return requests.get(url, params=params)
 
 MEASURE_COLUMNS = [(r['id'], ) for r in query('''
-SELECT id FROM observatory.obs_column
+SELECT id FROM obs_column
 WHERE type ILIKE 'numeric'
 AND weight > 0
 ''', is_meta=True).json()['rows']]
 
 CATEGORY_COLUMNS = [(r['id'], ) for r in query('''
-SELECT id FROM observatory.obs_column
+SELECT id FROM obs_column
 WHERE type ILIKE 'text'
 AND weight > 0
 ''', is_meta=True).json()['rows']]
 
 BOUNDARY_COLUMNS = [(r['id'], ) for r in query('''
-SELECT id FROM observatory.obs_column
+SELECT id FROM obs_column
 WHERE type ILIKE 'geometry'
 AND weight > 0
 ''', is_meta=True).json()['rows']]


### PR DESCRIPTION
If you want to simplify the automated testing regimen, you may want to cherry-pick this @ethervoid .