### PR TITLE
Obs dump version

### DIFF
--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -33,7 +33,8 @@ def select_star(tablename):
 
 cdb = Dumpr('observatory.cartodb.com','')
 
-metadata = ['obs_table', 'obs_column_table', 'obs_column', 'obs_column_tag', 'obs_tag', 'obs_column_to_column']
+metadata = ['obs_table', 'obs_column_table', 'obs_column', 'obs_column_tag',
+            'obs_tag', 'obs_column_to_column', 'obs_dump_version']
 
 fixtures = [
     ('us.census.tiger.census_tract', 'us.census.tiger.census_tract', '2014'),

--- a/src/pg/sql/40_observatory_utility.sql
+++ b/src/pg/sql/40_observatory_utility.sql
@@ -213,5 +213,6 @@ BEGIN
   EXECUTE '
     SELECT MAX(dump_id) FROM observatory.obs_dump_version
   ' INTO result;
+  RETURN result;
 END;
 $$ LANGUAGE plpgsql;

--- a/src/pg/sql/40_observatory_utility.sql
+++ b/src/pg/sql/40_observatory_utility.sql
@@ -199,3 +199,19 @@ BEGIN
   RETURN result;
 END;
 $$ LANGUAGE plpgsql;
+
+-- Function that returns the currently deployed obs_dump_version from the
+-- remote table of the same name.
+
+CREATE OR REPLACE FUNCTION cdb_observatory.OBS_DumpVersion(
+)
+  RETURNS TEXT
+AS $$
+DECLARE
+  result text;
+BEGIN
+  EXECUTE '
+    SELECT MAX(dump_id) FROM observatory.obs_dump_version
+  ' INTO result;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/pg/test/expected/40_observatory_utility_test.out
+++ b/src/pg/test/expected/40_observatory_utility_test.out
@@ -27,3 +27,6 @@ t
 _obs_standardizemeasurename_test
 t
 (1 row)
+obs_getdumpversion_notnull
+t
+(1 row)

--- a/src/pg/test/expected/40_observatory_utility_test.out
+++ b/src/pg/test/expected/40_observatory_utility_test.out
@@ -27,6 +27,6 @@ t
 _obs_standardizemeasurename_test
 t
 (1 row)
-obs_getdumpversion_notnull
+obs_dumpversion_notnull
 t
 (1 row)

--- a/src/pg/test/fixtures/drop_fixtures.sql
+++ b/src/pg/test/fixtures/drop_fixtures.sql
@@ -6,6 +6,7 @@ DROP TABLE IF EXISTS observatory.obs_column;
 DROP TABLE IF EXISTS observatory.obs_column_tag;
 DROP TABLE IF EXISTS observatory.obs_tag;
 DROP TABLE IF EXISTS observatory.obs_column_to_column;
+DROP TABLE IF EXISTS observatory.obs_dump_version;
 DROP TABLE IF EXISTS observatory.obs_65f29658e096ca1485bf683f65fdbc9f05ec3c5d;
 DROP TABLE IF EXISTS observatory.obs_1746e37b7cd28cb131971ea4187d42d71f09c5f3;
 DROP TABLE IF EXISTS observatory.obs_1a098da56badf5f32e336002b0a81708c40d29cd;

--- a/src/pg/test/sql/40_observatory_utility_test.sql
+++ b/src/pg/test/sql/40_observatory_utility_test.sql
@@ -75,4 +75,7 @@ SELECT cdb_observatory._OBS_GetRelatedColumn(
 -- should give back a standardized measure name
 SELECT cdb_observatory._OBS_StandardizeMeasureName('test 343 %% 2 qqq }}{{}}') = 'test_343_2_qqq' As _OBS_StandardizeMeasureName_test;
 
+SELECT cdb_observatory.OBS_GetDumpVersion()
+  IS NOT NULL AS OBS_GetDumpVersion_notnull;
+
 \i test/fixtures/drop_fixtures.sql

--- a/src/pg/test/sql/40_observatory_utility_test.sql
+++ b/src/pg/test/sql/40_observatory_utility_test.sql
@@ -75,7 +75,7 @@ SELECT cdb_observatory._OBS_GetRelatedColumn(
 -- should give back a standardized measure name
 SELECT cdb_observatory._OBS_StandardizeMeasureName('test 343 %% 2 qqq }}{{}}') = 'test_343_2_qqq' As _OBS_StandardizeMeasureName_test;
 
-SELECT cdb_observatory.OBS_GetDumpVersion()
-  IS NOT NULL AS OBS_GetDumpVersion_notnull;
+SELECT cdb_observatory.OBS_DumpVersion()
+  IS NOT NULL AS OBS_DumpVersion_notnull;
 
 \i test/fixtures/drop_fixtures.sql


### PR DESCRIPTION
Resolves #114 .

Chose to just test returns NOT NULL because every time we update fixtures the dump version is liable to change.

@ohasselblad CR please?  Opened a blank release-v-0.0.6 branch so that we have a clean PR when we decide to deploy.