### PR TITLE
Geom_ref colname from geom table used with data table, too

### DIFF
--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -633,7 +633,7 @@ BEGIN
   q := q || q_select || format('FROM observatory.%I ', ((data_table_info)[1]->>'tablename'));
 
   q := format(q || ' ) ' || q_sum || ' ]::numeric[] FROM _overlaps, values
-  WHERE values.%I = _overlaps.%I', geom_geoid_colname, geom_geoid_colname);
+  WHERE values.%I = _overlaps.%I', data_geoid_colname, geom_geoid_colname);
 
   EXECUTE
     q


### PR DESCRIPTION
Also enables our `obsgetmeasure_area` tests, so this can't creep up on us again in the future!

Resolves https://github.com/CartoDB/observatory-extension/issues/121 .

All tests pass on envisage, plus the UK area tests now pass.  Can you take a quick look @ohasselblad ? Would like to get this rolled up into our next release with the other outstanding PRs ASAP.