### PR TITLE
Release v 1.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,29 @@
+1.0.0 (6/27/2016)
+-----
+
+* Incremented to 1.0.0 to be in compliance with [SemVer](http://semver.org/),
+  which disallows use of 0.x.x versions.  This also reflects that we are
+  already in production.
+
+__API Changes__
+
+* Added `OBS_DumpVersion` to look up version data ([#118](https://github.com/CartoDB/observatory-extension/pull/118))
+
+__Improvements__
+
+* Whether data exists for a geom now determined by polygon intersection instead of
+  BBOX overlap ([#119](https://github.com/CartoDB/observatory-extension/pull/119))
+* Automated tests cover Spanish and UK data
+  ([#115](https://github.com/CartoDB/observatory-extension/pull/115))
+* Automated tests cover `OBS_GetUSCensusMeasure`
+  ([#105](https://github.com/CartoDB/observatory-extension/pull/105))
+
+__Bugfixes__
+
+* Geom table can have different `geomref_colname` than the data table
+  ([#123](https://github.com/CartoDB/observatory-extension/pull/123))
+
+
 0.0.5 (5/27/2016)
 -----
 * Adds new function `OBS_GetMeasureById` ([#96](https://github.com/CartoDB/observatory-extension/pull/96))

--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -33,7 +33,8 @@ def select_star(tablename):
 
 cdb = Dumpr('observatory.cartodb.com','')
 
-metadata = ['obs_table', 'obs_column_table', 'obs_column', 'obs_column_tag', 'obs_tag', 'obs_column_to_column']
+metadata = ['obs_table', 'obs_column_table', 'obs_column', 'obs_column_tag',
+            'obs_tag', 'obs_column_to_column', 'obs_dump_version']
 
 fixtures = [
     ('us.census.tiger.census_tract', 'us.census.tiger.census_tract', '2014'),

--- a/src/pg/observatory.control
+++ b/src/pg/observatory.control
@@ -1,5 +1,5 @@
 comment = 'CartoDB Observatory backend extension'
-default_version = '0.0.5'
+default_version = '1.0.0'
 requires = 'postgis'
 superuser = true
 schema = cdb_observatory

--- a/src/pg/sql/40_observatory_utility.sql
+++ b/src/pg/sql/40_observatory_utility.sql
@@ -199,3 +199,20 @@ BEGIN
   RETURN result;
 END;
 $$ LANGUAGE plpgsql;
+
+-- Function that returns the currently deployed obs_dump_version from the
+-- remote table of the same name.
+
+CREATE OR REPLACE FUNCTION cdb_observatory.OBS_DumpVersion(
+)
+  RETURNS TEXT
+AS $$
+DECLARE
+  result text;
+BEGIN
+  EXECUTE '
+    SELECT MAX(dump_id) FROM observatory.obs_dump_version
+  ' INTO result;
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -633,7 +633,7 @@ BEGIN
   q := q || q_select || format('FROM observatory.%I ', ((data_table_info)[1]->>'tablename'));
 
   q := format(q || ' ) ' || q_sum || ' ]::numeric[] FROM _overlaps, values
-  WHERE values.%I = _overlaps.%I', geom_geoid_colname, geom_geoid_colname);
+  WHERE values.%I = _overlaps.%I', data_geoid_colname, geom_geoid_colname);
 
   EXECUTE
     q

--- a/src/pg/sql/42_observatory_exploration.sql
+++ b/src/pg/sql/42_observatory_exploration.sql
@@ -114,7 +114,7 @@ BEGIN
       AND
         observatory.OBS_column.type = 'Geometry'
       AND
-        $1 && bounds::box2d
+        ST_Intersects($1, observatory.obs_table.the_geom)
   $string$ || timespan_query
   USING geom;
   RETURN;

--- a/src/pg/test/expected/40_observatory_utility_test.out
+++ b/src/pg/test/expected/40_observatory_utility_test.out
@@ -27,3 +27,6 @@ t
 _obs_standardizemeasurename_test
 t
 (1 row)
+obs_dumpversion_notnull
+t
+(1 row)

--- a/src/pg/test/fixtures/drop_fixtures.sql
+++ b/src/pg/test/fixtures/drop_fixtures.sql
@@ -6,6 +6,7 @@ DROP TABLE IF EXISTS observatory.obs_column;
 DROP TABLE IF EXISTS observatory.obs_column_tag;
 DROP TABLE IF EXISTS observatory.obs_tag;
 DROP TABLE IF EXISTS observatory.obs_column_to_column;
+DROP TABLE IF EXISTS observatory.obs_dump_version;
 DROP TABLE IF EXISTS observatory.obs_65f29658e096ca1485bf683f65fdbc9f05ec3c5d;
 DROP TABLE IF EXISTS observatory.obs_1746e37b7cd28cb131971ea4187d42d71f09c5f3;
 DROP TABLE IF EXISTS observatory.obs_1a098da56badf5f32e336002b0a81708c40d29cd;

--- a/src/pg/test/sql/40_observatory_utility_test.sql
+++ b/src/pg/test/sql/40_observatory_utility_test.sql
@@ -75,4 +75,7 @@ SELECT cdb_observatory._OBS_GetRelatedColumn(
 -- should give back a standardized measure name
 SELECT cdb_observatory._OBS_StandardizeMeasureName('test 343 %% 2 qqq }}{{}}') = 'test_343_2_qqq' As _OBS_StandardizeMeasureName_test;
 
+SELECT cdb_observatory.OBS_DumpVersion()
+  IS NOT NULL AS OBS_DumpVersion_notnull;
+
 \i test/fixtures/drop_fixtures.sql


### PR DESCRIPTION
@ethervoid this should be good to go.  Currently we have a bug blocking full use of UK data, so would be good to get it out ASAP.

A word on the version change -- this does *not* include breaking changes with prior versions, so no worries there.  It's just that 0.x.x releases should a) be reserved only for pre-production (which we're not) and b) are prohibited in SemVer 2.  So I'm taking the opportunity to boost us to 1.0.0 status.

Technically, this would be a minor version change, since we're adding a new function but not breaking any backwards compatbility.