### PR TITLE
preemptively set_srid for obs_getavailableboundaries

### DIFF
--- a/src/pg/sql/42_observatory_exploration.sql
+++ b/src/pg/sql/42_observatory_exploration.sql
@@ -114,7 +114,7 @@ BEGIN
       AND
         observatory.OBS_column.type = 'Geometry'
       AND
-        ST_Intersects($1, observatory.obs_table.the_geom)
+        ST_Intersects($1, st_setsrid(observatory.obs_table.the_geom, 4326))
   $string$ || timespan_query
   USING geom;
   RETURN;


### PR DESCRIPTION
Should resolve obs_getavailableboundaries mixed SRID complaint on staging found in https://github.com/CartoDB/observatory-extension/issues/129 .

If this looks good as an approach (the more long-lasting fix is to define an SRID for obs_table) then I will bump the control to 1.0.1.