### PR TITLE
Fix hardcoded getcategory geom

### DIFF
--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -96,22 +96,28 @@ with open('src/pg/test/fixtures/load_fixtures.sql', 'w') as outfile:
 ALTER TABLE observatory.obs_table
   ADD PRIMARY KEY (id);
 ALTER TABLE observatory.obs_column_table
-  ADD PRIMARY KEY (column_id, table_id),
-  ADD FOREIGN KEY (column_id) REFERENCES observatory.obs_column(id) ON DELETE CASCADE,
-  ADD FOREIGN KEY (table_id) REFERENCES observatory.obs_table(id) ON DELETE CASCADE;
+  ADD PRIMARY KEY (column_id, table_id);
+CREATE UNIQUE INDEX ON observatory.obs_column_table (table_id, column_id);
 CREATE UNIQUE INDEX ON observatory.obs_column_table (table_id, colname);
 ALTER TABLE observatory.obs_column
   ADD PRIMARY KEY (id);
 ALTER TABLE observatory.obs_column_to_column
-  ADD PRIMARY KEY (source_id, target_id, reltype),
-  ADD FOREIGN KEY (source_id) REFERENCES observatory.obs_column(id) ON DELETE CASCADE,
-  ADD FOREIGN KEY (target_id) REFERENCES observatory.obs_column(id) ON DELETE CASCADE;
+  ADD PRIMARY KEY (source_id, target_id, reltype);
+CREATE UNIQUE INDEX ON observatory.obs_column_to_column (target_id, source_id, reltype);
+CREATE INDEX ON observatory.obs_column_to_column (reltype);
 ALTER TABLE observatory.obs_column_tag
-  ADD PRIMARY KEY (column_id, tag_id),
-  ADD FOREIGN KEY (column_id) REFERENCES observatory.obs_column(id) ON DELETE CASCADE,
-  ADD FOREIGN KEY (tag_id) REFERENCES observatory.obs_tag(id) ON DELETE CASCADE;
+  ADD PRIMARY KEY (column_id, tag_id);
+CREATE UNIQUE INDEX ON observatory.obs_column_tag (tag_id, column_id);
 ALTER TABLE observatory.obs_tag
   ADD PRIMARY KEY (id);
+CREATE INDEX ON observatory.obs_tag (type);
+
+VACUUM ANALYZE observatory.obs_table;
+VACUUM ANALYZE observatory.obs_column_table;
+VACUUM ANALYZE observatory.obs_column;
+VACUUM ANALYZE observatory.obs_column_to_column;
+VACUUM ANALYZE observatory.obs_column_tag;
+VACUUM ANALYZE observatory.obs_tag;
 
 CREATE TABLE observatory.obs_meta AS
 SELECT numer_c.id numer_id,

--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -34,7 +34,7 @@ def select_star(tablename):
 cdb = Dumpr('observatory.cartodb.com','')
 
 metadata = ['obs_table', 'obs_column_table', 'obs_column', 'obs_column_tag',
-            'obs_tag', 'obs_column_to_column', 'obs_dump_version']
+            'obs_tag', 'obs_column_to_column', 'obs_dump_version', ]
 
 fixtures = [
     ('us.census.tiger.census_tract', 'us.census.tiger.census_tract', '2014'),
@@ -90,3 +90,98 @@ with open('src/pg/test/fixtures/load_fixtures.sql', 'w') as outfile:
             cdb.dump(' '.join([select_star(tablename), "WHERE {}::text {} {}".format(colname, compare, where)]),
                      tablename, outfile, schema='observatory')
             dropfiles.write('DROP TABLE IF EXISTS observatory.{};\n'.format(tablename))
+
+
+        outfile.write('''
+        CREATE TABLE observatory.obs_meta AS
+        SELECT numer_c.id numer_id,
+                   denom_c.id denom_id,
+                   geom_c.id geom_id,
+                   MAX(numer_c.name) numer_name,
+                   MAX(denom_c.name) denom_name,
+                   MAX(geom_c.name) geom_name,
+                   MAX(numer_c.description) numer_description,
+                   MAX(denom_c.description) denom_description,
+                   MAX(geom_c.description) geom_description,
+                   MAX(numer_c.aggregate) numer_aggregate,
+                   MAX(denom_c.aggregate) denom_aggregate,
+                   MAX(geom_c.aggregate) geom_aggregate,
+                   MAX(numer_c.type) numer_type,
+                   MAX(denom_c.type) denom_type,
+                   MAX(geom_c.type) geom_type,
+                   MAX(numer_data_ct.colname) numer_colname,
+                   MAX(denom_data_ct.colname) denom_colname,
+                   MAX(geom_geom_ct.colname) geom_colname,
+                   MAX(numer_geomref_ct.colname) numer_geomref_colname,
+                   MAX(denom_geomref_ct.colname) denom_geomref_colname,
+                   MAX(geom_geomref_ct.colname) geom_geomref_colname,
+                   MAX(numer_t.tablename) numer_tablename,
+                   MAX(denom_t.tablename) denom_tablename,
+                   MAX(geom_t.tablename) geom_tablename,
+                   MAX(numer_t.timespan) numer_timespan,
+                   MAX(denom_t.timespan) denom_timespan,
+                   MAX(numer_c.weight) numer_weight,
+                   MAX(denom_c.weight) denom_weight,
+                   MAX(geom_c.weight) geom_weight,
+                   MAX(geom_t.timespan) geom_timespan,
+                   MAX(geom_t.the_geom_webmercator)::geometry AS the_geom_webmercator,
+                   ARRAY_AGG(DISTINCT s_tag.id) section_tags,
+                   ARRAY_AGG(DISTINCT ss_tag.id) subsection_tags,
+                   ARRAY_AGG(DISTINCT unit_tag.id) unit_tags
+            FROM observatory.obs_column_table numer_data_ct,
+                 observatory.obs_table numer_t,
+                 observatory.obs_column_table numer_geomref_ct,
+                 observatory.obs_column geomref_c,
+                 observatory.obs_column_to_column geomref_c2c,
+                 observatory.obs_column geom_c,
+                 observatory.obs_column_table geom_geom_ct,
+                 observatory.obs_column_table geom_geomref_ct,
+                 observatory.obs_table geom_t,
+                 observatory.obs_column_tag ss_ctag,
+                 observatory.obs_tag ss_tag,
+                 observatory.obs_column_tag s_ctag,
+                 observatory.obs_tag s_tag,
+                 observatory.obs_column_tag unit_ctag,
+                 observatory.obs_tag unit_tag,
+                 observatory.obs_column numer_c
+              LEFT JOIN (
+                observatory.obs_column_to_column denom_c2c
+                JOIN observatory.obs_column denom_c ON denom_c2c.target_id = denom_c.id
+                JOIN observatory.obs_column_table denom_data_ct ON denom_data_ct.column_id = denom_c.id
+                JOIN observatory.obs_table denom_t ON denom_data_ct.table_id = denom_t.id
+                JOIN observatory.obs_column_table denom_geomref_ct ON denom_geomref_ct.table_id = denom_t.id
+              ) ON denom_c2c.source_id = numer_c.id
+            WHERE numer_c.id = numer_data_ct.column_id
+              AND numer_data_ct.table_id = numer_t.id
+              AND numer_t.id = numer_geomref_ct.table_id
+              AND numer_geomref_ct.column_id = geomref_c.id
+              AND geomref_c2c.reltype = 'geom_ref'
+              AND geomref_c.id = geomref_c2c.source_id
+              AND geom_c.id = geomref_c2c.target_id
+              AND geom_geomref_ct.column_id = geomref_c.id
+              AND geom_geomref_ct.table_id = geom_t.id
+              AND geom_geom_ct.column_id = geom_c.id
+              AND geom_geom_ct.table_id = geom_t.id
+              AND geom_c.type ILIKE 'geometry'
+              AND numer_c.type NOT ILIKE 'geometry'
+              AND numer_t.id != geom_t.id
+              AND numer_c.id != geomref_c.id
+              AND unit_tag.type = 'unit'
+              AND ss_tag.type = 'subsection'
+              AND s_tag.type = 'section'
+              AND unit_ctag.column_id = numer_c.id
+              AND unit_ctag.tag_id = unit_tag.id
+              AND ss_ctag.column_id = numer_c.id
+              AND ss_ctag.tag_id = ss_tag.id
+              AND s_ctag.column_id = numer_c.id
+              AND s_ctag.tag_id = s_tag.id
+              AND (denom_c2c.reltype = 'denominator' OR denom_c2c.reltype IS NULL)
+              AND (denom_geomref_ct.column_id = geomref_c.id OR denom_geomref_ct.column_id IS NULL)
+              AND (denom_t.timespan = numer_t.timespan OR denom_t.timespan IS NULL)
+            GROUP BY numer_c.id, denom_c.id, geom_c.id,
+                     numer_t.id, denom_t.id, geom_t.id;
+        ''')
+
+        dropfiles.write('''
+        DROP TABLE IF EXISTS observatory.obs_meta
+                        ''')

--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -93,95 +93,115 @@ with open('src/pg/test/fixtures/load_fixtures.sql', 'w') as outfile:
 
 
         outfile.write('''
-        CREATE TABLE observatory.obs_meta AS
-        SELECT numer_c.id numer_id,
-                   denom_c.id denom_id,
-                   geom_c.id geom_id,
-                   MAX(numer_c.name) numer_name,
-                   MAX(denom_c.name) denom_name,
-                   MAX(geom_c.name) geom_name,
-                   MAX(numer_c.description) numer_description,
-                   MAX(denom_c.description) denom_description,
-                   MAX(geom_c.description) geom_description,
-                   MAX(numer_c.aggregate) numer_aggregate,
-                   MAX(denom_c.aggregate) denom_aggregate,
-                   MAX(geom_c.aggregate) geom_aggregate,
-                   MAX(numer_c.type) numer_type,
-                   MAX(denom_c.type) denom_type,
-                   MAX(geom_c.type) geom_type,
-                   MAX(numer_data_ct.colname) numer_colname,
-                   MAX(denom_data_ct.colname) denom_colname,
-                   MAX(geom_geom_ct.colname) geom_colname,
-                   MAX(numer_geomref_ct.colname) numer_geomref_colname,
-                   MAX(denom_geomref_ct.colname) denom_geomref_colname,
-                   MAX(geom_geomref_ct.colname) geom_geomref_colname,
-                   MAX(numer_t.tablename) numer_tablename,
-                   MAX(denom_t.tablename) denom_tablename,
-                   MAX(geom_t.tablename) geom_tablename,
-                   MAX(numer_t.timespan) numer_timespan,
-                   MAX(denom_t.timespan) denom_timespan,
-                   MAX(numer_c.weight) numer_weight,
-                   MAX(denom_c.weight) denom_weight,
-                   MAX(geom_c.weight) geom_weight,
-                   MAX(geom_t.timespan) geom_timespan,
-                   MAX(geom_t.the_geom_webmercator)::geometry AS the_geom_webmercator,
-                   ARRAY_AGG(DISTINCT s_tag.id) section_tags,
-                   ARRAY_AGG(DISTINCT ss_tag.id) subsection_tags,
-                   ARRAY_AGG(DISTINCT unit_tag.id) unit_tags
-            FROM observatory.obs_column_table numer_data_ct,
-                 observatory.obs_table numer_t,
-                 observatory.obs_column_table numer_geomref_ct,
-                 observatory.obs_column geomref_c,
-                 observatory.obs_column_to_column geomref_c2c,
-                 observatory.obs_column geom_c,
-                 observatory.obs_column_table geom_geom_ct,
-                 observatory.obs_column_table geom_geomref_ct,
-                 observatory.obs_table geom_t,
-                 observatory.obs_column_tag ss_ctag,
-                 observatory.obs_tag ss_tag,
-                 observatory.obs_column_tag s_ctag,
-                 observatory.obs_tag s_tag,
-                 observatory.obs_column_tag unit_ctag,
-                 observatory.obs_tag unit_tag,
-                 observatory.obs_column numer_c
-              LEFT JOIN (
-                observatory.obs_column_to_column denom_c2c
-                JOIN observatory.obs_column denom_c ON denom_c2c.target_id = denom_c.id
-                JOIN observatory.obs_column_table denom_data_ct ON denom_data_ct.column_id = denom_c.id
-                JOIN observatory.obs_table denom_t ON denom_data_ct.table_id = denom_t.id
-                JOIN observatory.obs_column_table denom_geomref_ct ON denom_geomref_ct.table_id = denom_t.id
-              ) ON denom_c2c.source_id = numer_c.id
-            WHERE numer_c.id = numer_data_ct.column_id
-              AND numer_data_ct.table_id = numer_t.id
-              AND numer_t.id = numer_geomref_ct.table_id
-              AND numer_geomref_ct.column_id = geomref_c.id
-              AND geomref_c2c.reltype = 'geom_ref'
-              AND geomref_c.id = geomref_c2c.source_id
-              AND geom_c.id = geomref_c2c.target_id
-              AND geom_geomref_ct.column_id = geomref_c.id
-              AND geom_geomref_ct.table_id = geom_t.id
-              AND geom_geom_ct.column_id = geom_c.id
-              AND geom_geom_ct.table_id = geom_t.id
-              AND geom_c.type ILIKE 'geometry'
-              AND numer_c.type NOT ILIKE 'geometry'
-              AND numer_t.id != geom_t.id
-              AND numer_c.id != geomref_c.id
-              AND unit_tag.type = 'unit'
-              AND ss_tag.type = 'subsection'
-              AND s_tag.type = 'section'
-              AND unit_ctag.column_id = numer_c.id
-              AND unit_ctag.tag_id = unit_tag.id
-              AND ss_ctag.column_id = numer_c.id
-              AND ss_ctag.tag_id = ss_tag.id
-              AND s_ctag.column_id = numer_c.id
-              AND s_ctag.tag_id = s_tag.id
-              AND (denom_c2c.reltype = 'denominator' OR denom_c2c.reltype IS NULL)
-              AND (denom_geomref_ct.column_id = geomref_c.id OR denom_geomref_ct.column_id IS NULL)
-              AND (denom_t.timespan = numer_t.timespan OR denom_t.timespan IS NULL)
-            GROUP BY numer_c.id, denom_c.id, geom_c.id,
-                     numer_t.id, denom_t.id, geom_t.id;
+ALTER TABLE observatory.obs_table
+  ADD PRIMARY KEY (id);
+ALTER TABLE observatory.obs_column_table
+  ADD PRIMARY KEY (column_id, table_id),
+  ADD FOREIGN KEY (column_id) REFERENCES observatory.obs_column(id) ON DELETE CASCADE,
+  ADD FOREIGN KEY (table_id) REFERENCES observatory.obs_table(id) ON DELETE CASCADE;
+CREATE UNIQUE INDEX ON observatory.obs_column_table (table_id, colname);
+ALTER TABLE observatory.obs_column
+  ADD PRIMARY KEY (id);
+ALTER TABLE observatory.obs_column_to_column
+  ADD PRIMARY KEY (source_id, target_id, reltype),
+  ADD FOREIGN KEY (source_id) REFERENCES observatory.obs_column(id) ON DELETE CASCADE,
+  ADD FOREIGN KEY (target_id) REFERENCES observatory.obs_column(id) ON DELETE CASCADE;
+ALTER TABLE observatory.obs_column_tag
+  ADD PRIMARY KEY (column_id, tag_id),
+  ADD FOREIGN KEY (column_id) REFERENCES observatory.obs_column(id) ON DELETE CASCADE,
+  ADD FOREIGN KEY (tag_id) REFERENCES observatory.obs_tag(id) ON DELETE CASCADE;
+ALTER TABLE observatory.obs_tag
+  ADD PRIMARY KEY (id);
+
+CREATE TABLE observatory.obs_meta AS
+SELECT numer_c.id numer_id,
+       denom_c.id denom_id,
+       geom_c.id geom_id,
+       MAX(numer_c.name) numer_name,
+       MAX(denom_c.name) denom_name,
+       MAX(geom_c.name) geom_name,
+       MAX(numer_c.description) numer_description,
+       MAX(denom_c.description) denom_description,
+       MAX(geom_c.description) geom_description,
+       MAX(numer_c.aggregate) numer_aggregate,
+       MAX(denom_c.aggregate) denom_aggregate,
+       MAX(geom_c.aggregate) geom_aggregate,
+       MAX(numer_c.type) numer_type,
+       MAX(denom_c.type) denom_type,
+       MAX(geom_c.type) geom_type,
+       MAX(numer_data_ct.colname) numer_colname,
+       MAX(denom_data_ct.colname) denom_colname,
+       MAX(geom_geom_ct.colname) geom_colname,
+       MAX(numer_geomref_ct.colname) numer_geomref_colname,
+       MAX(denom_geomref_ct.colname) denom_geomref_colname,
+       MAX(geom_geomref_ct.colname) geom_geomref_colname,
+       MAX(numer_t.tablename) numer_tablename,
+       MAX(denom_t.tablename) denom_tablename,
+       MAX(geom_t.tablename) geom_tablename,
+       MAX(numer_t.timespan) numer_timespan,
+       MAX(denom_t.timespan) denom_timespan,
+       MAX(numer_c.weight) numer_weight,
+       MAX(denom_c.weight) denom_weight,
+       MAX(geom_c.weight) geom_weight,
+       MAX(geom_t.timespan) geom_timespan,
+       MAX(geom_t.the_geom_webmercator)::geometry AS the_geom_webmercator,
+       ARRAY_AGG(DISTINCT s_tag.id) section_tags,
+       ARRAY_AGG(DISTINCT ss_tag.id) subsection_tags,
+       ARRAY_AGG(DISTINCT unit_tag.id) unit_tags
+FROM observatory.obs_column_table numer_data_ct,
+     observatory.obs_table numer_t,
+     observatory.obs_column_table numer_geomref_ct,
+     observatory.obs_column geomref_c,
+     observatory.obs_column_to_column geomref_c2c,
+     observatory.obs_column geom_c,
+     observatory.obs_column_table geom_geom_ct,
+     observatory.obs_column_table geom_geomref_ct,
+     observatory.obs_table geom_t,
+     observatory.obs_column_tag ss_ctag,
+     observatory.obs_tag ss_tag,
+     observatory.obs_column_tag s_ctag,
+     observatory.obs_tag s_tag,
+     observatory.obs_column_tag unit_ctag,
+     observatory.obs_tag unit_tag,
+     observatory.obs_column numer_c
+  LEFT JOIN (
+    observatory.obs_column_to_column denom_c2c
+    JOIN observatory.obs_column denom_c ON denom_c2c.target_id = denom_c.id
+    JOIN observatory.obs_column_table denom_data_ct ON denom_data_ct.column_id = denom_c.id
+    JOIN observatory.obs_table denom_t ON denom_data_ct.table_id = denom_t.id
+    JOIN observatory.obs_column_table denom_geomref_ct ON denom_geomref_ct.table_id = denom_t.id
+  ) ON denom_c2c.source_id = numer_c.id
+WHERE numer_c.id = numer_data_ct.column_id
+  AND numer_data_ct.table_id = numer_t.id
+  AND numer_t.id = numer_geomref_ct.table_id
+  AND numer_geomref_ct.column_id = geomref_c.id
+  AND geomref_c2c.reltype = 'geom_ref'
+  AND geomref_c.id = geomref_c2c.source_id
+  AND geom_c.id = geomref_c2c.target_id
+  AND geom_geomref_ct.column_id = geomref_c.id
+  AND geom_geomref_ct.table_id = geom_t.id
+  AND geom_geom_ct.column_id = geom_c.id
+  AND geom_geom_ct.table_id = geom_t.id
+  AND geom_c.type ILIKE 'geometry'
+  AND numer_c.type NOT ILIKE 'geometry'
+  AND numer_t.id != geom_t.id
+  AND numer_c.id != geomref_c.id
+  AND unit_tag.type = 'unit'
+  AND ss_tag.type = 'subsection'
+  AND s_tag.type = 'section'
+  AND unit_ctag.column_id = numer_c.id
+  AND unit_ctag.tag_id = unit_tag.id
+  AND ss_ctag.column_id = numer_c.id
+  AND ss_ctag.tag_id = ss_tag.id
+  AND s_ctag.column_id = numer_c.id
+  AND s_ctag.tag_id = s_tag.id
+  AND (denom_c2c.reltype = 'denominator' OR denom_c2c.reltype IS NULL)
+  AND (denom_geomref_ct.column_id = geomref_c.id OR denom_geomref_ct.column_id IS NULL)
+  AND (denom_t.timespan = numer_t.timespan OR denom_t.timespan IS NULL)
+GROUP BY numer_c.id, denom_c.id, geom_c.id,
+         numer_t.id, denom_t.id, geom_t.id;
         ''')
 
         dropfiles.write('''
-        DROP TABLE IF EXISTS observatory.obs_meta
+DROP TABLE IF EXISTS observatory.obs_meta;
                         ''')

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -457,8 +457,6 @@ BEGIN
          geom_geomref_colname, geom_colname, geom_table
     USING COALESCE(boundary_id, ''), category_id, COALESCE(time_span, '');
 
-  RAISE DEBUG 'target_table %, colname %', target_table, colname;
-
   EXECUTE format(
       'SELECT %I
        FROM observatory.%I data, observatory.%I geom

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -470,11 +470,11 @@ BEGIN
   ELSE
     -- favor the category with the most area
     EXECUTE format(
-       'SELECT %I category, SUM(overlap_fraction) category_share
+       'SELECT data.%I category, SUM(overlap_fraction) category_share
         FROM observatory.%I data, (
           SELECT ST_Area(
            ST_Intersection(%L, a.%I)
-          ) / ST_Area(%L) AS overlap_fraction, %I geomref
+          ) / ST_Area(%L) AS overlap_fraction, a.%I geomref
           FROM observatory.%I as a
           WHERE %L && a.%I) _overlaps
         WHERE data.%I = _overlaps.geomref

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -466,7 +466,7 @@ BEGIN
          AND ST_WITHIN(%L, geom.%I) ',
        colname,
        data_table,
-       geom_table
+       geom_table,
        data_geomref_colname,
        geom_geomref_colname,
        geom,

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -404,7 +404,7 @@ BEGIN
               AND (numer_timespan = %L OR (%L = ''''))
             ORDER BY numer_timespan DESC
             LIMIT 1 ',
-                boundary_id, measure_id, nullif(time_span, ''), nullif(time_span, ''))
+                boundary_id, measure_id, coalesce(time_span, ''), coalesce(time_span, ''))
 
     INTO colname, data_geoid_colname, target_table;
 

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -404,7 +404,7 @@ BEGIN
               AND (numer_timespan = %L OR (%L IS NULL))
             ORDER BY numer_timespan DESC
             LIMIT 1 ',
-                boundary_id, measure_id)
+                boundary_id, measure_id, time_span, time_span)
     INTO colname, data_geoid_colname, target_table;
 
   RAISE DEBUG 'target_table %, colname %', target_table, colname;

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -401,10 +401,11 @@ BEGIN
             FROM observatory.obs_meta
             WHERE geom_id = %L
               AND numer_id = %L
-              AND (numer_timespan = %L OR (%L IS NULL))
+              AND (numer_timespan = %L OR (%L = ''''))
             ORDER BY numer_timespan DESC
             LIMIT 1 ',
-                boundary_id, measure_id, time_span, time_span)
+                boundary_id, measure_id, nullif(time_span, ''), nullif(time_span, ''))
+
     INTO colname, data_geoid_colname, target_table;
 
   RAISE DEBUG 'target_table %, colname %', target_table, colname;

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -453,8 +453,8 @@ BEGIN
              ORDER BY geom_weight DESC, numer_timespan DESC
              LIMIT 1
      $query$
-    INTO colname, data_geomref_colname, data_table, geom_geomref_colname,
-         geom_colname, geom_table
+    INTO colname, data_geomref_colname, data_table,
+         geom_geomref_colname, geom_colname, geom_table
     USING COALESCE(boundary_id, ''), category_id, COALESCE(time_span, '');
 
   RAISE DEBUG 'target_table %, colname %', target_table, colname;

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -471,10 +471,10 @@ BEGIN
     EXECUTE format(
        'WITH _overlaps AS (
           SELECT ST_Area(
-            ST_Intersection(%I, a.%I)
+            ST_Intersection(%L, a.%I)
           ) / ST_Area(a.%I) AS overlap_fraction, %I geomref
           FROM observatory.%I as a
-          WHERE %I && a.%I,
+          WHERE %L && a.%I,
         SELECT %I category
          FROM observatory.%I data
          WHERE data.%I = geomref

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -474,7 +474,7 @@ BEGIN
             ST_Intersection(%L, a.%I)
           ) / ST_Area(a.%I) AS overlap_fraction, %I geomref
           FROM observatory.%I as a
-          WHERE %L && a.%I,
+          WHERE %L && a.%I
         SELECT %I category
          FROM observatory.%I data
          WHERE data.%I = geomref

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -397,16 +397,17 @@ DECLARE
 BEGIN
 
   EXECUTE
-    format('SELECT numer_colname, numer_geomref_colname, numer_tablename
-            FROM observatory.obs_meta
-            WHERE geom_id = %L
-              AND numer_id = %L
-              AND (numer_timespan = %L OR (%L = ''''))
-            ORDER BY numer_timespan DESC
-            LIMIT 1 ',
-                boundary_id, measure_id, coalesce(time_span, ''), coalesce(time_span, ''))
-
-    INTO colname, data_geoid_colname, target_table;
+     $query$
+     SELECT numer_colname, numer_geomref_colname, numer_tablename
+             FROM observatory.obs_meta
+             WHERE (geom_id = $1 OR ($1 = ''))
+               AND numer_id = $2
+               AND (numer_timespan = $3 OR ($3 = ''))
+             ORDER BY geom_weight DESC, numer_timespan DESC
+             LIMIT 1
+     $query$
+    INTO colname, data_geoid_colname, target_table
+    USING COALESCE(boundary_id, ''), measure_id, COALESCE(time_span, '');
 
   RAISE DEBUG 'target_table %, colname %', target_table, colname;
 

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -474,7 +474,7 @@ BEGIN
             ST_Intersection(%L, a.%I)
           ) / ST_Area(a.%I) AS overlap_fraction, %I geomref
           FROM observatory.%I as a
-          WHERE %L && a.%I),
+          WHERE %L && a.%I)
         SELECT %I category
          FROM observatory.%I data
          WHERE data.%I = geomref

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -474,7 +474,7 @@ BEGIN
             ST_Intersection(%L, a.%I)
           ) / ST_Area(a.%I) AS overlap_fraction, %I geomref
           FROM observatory.%I as a
-          WHERE %L && a.%I
+          WHERE %L && a.%I),
         SELECT %I category
          FROM observatory.%I data
          WHERE data.%I = geomref

--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -460,7 +460,7 @@ BEGIN
 
   IF ST_GeometryType(geom) = 'ST_Point' THEN
     EXECUTE format(
-        'SELECT %I
+        'SELECT data.%I
          FROM observatory.%I data, observatory.%I geom
          WHERE data.%I = geom.%I
            AND ST_WITHIN(%L, geom.%I) ',

--- a/src/pg/test/expected/41_observatory_augmentation_test.out
+++ b/src/pg/test/expected/41_observatory_augmentation_test.out
@@ -1,5 +1,4 @@
-\i test/fixtures/load_fixtures.sql
-SET client_min_messages TO WARNING;
+\pset format unaligned
 \set ECHO none
 obs_getdemographicsnapshot_test_no_returns
 t

--- a/src/pg/test/expected/42_observatory_exploration_test.out
+++ b/src/pg/test/expected/42_observatory_exploration_test.out
@@ -1,4 +1,3 @@
-\i test/fixtures/load_fixtures.sql
 SET client_min_messages TO WARNING;
 \set ECHO none
 _obs_searchtables_tables_match|_obs_searchtables_timespan_matches

--- a/src/pg/test/expected/42_observatory_exploration_test.out
+++ b/src/pg/test/expected/42_observatory_exploration_test.out
@@ -1,4 +1,4 @@
-SET client_min_messages TO WARNING;
+\pset format unaligned
 \set ECHO none
 _obs_searchtables_tables_match|_obs_searchtables_timespan_matches
 t|t

--- a/src/pg/test/expected/44_observatory_geometries_test.out
+++ b/src/pg/test/expected/44_observatory_geometries_test.out
@@ -1,6 +1,4 @@
 \pset format unaligned
-\set ECHO all
-SET client_min_messages TO WARNING;
 \set ECHO none
 obs_getboundary_cartodb_census_tract
 t

--- a/src/pg/test/expected/44_observatory_geometries_test.out
+++ b/src/pg/test/expected/44_observatory_geometries_test.out
@@ -1,6 +1,5 @@
 \pset format unaligned
 \set ECHO all
-\i test/fixtures/load_fixtures.sql
 SET client_min_messages TO WARNING;
 \set ECHO none
 obs_getboundary_cartodb_census_tract

--- a/src/pg/test/fixtures/drop_fixtures.sql
+++ b/src/pg/test/fixtures/drop_fixtures.sql
@@ -21,5 +21,4 @@ DROP TABLE IF EXISTS observatory.obs_d39f7fe5959891c8296490d83c22ded31c54af13;
 DROP TABLE IF EXISTS observatory.obs_144e8b4f906885b2e057ac4842644a553ae49c6e;
 DROP TABLE IF EXISTS observatory.obs_c6fb99c47d61289fbb8e561ff7773799d3fcc308;
 
-        DROP TABLE IF EXISTS observatory.obs_meta
-                        
+DROP TABLE IF EXISTS observatory.obs_meta;

--- a/src/pg/test/fixtures/drop_fixtures.sql
+++ b/src/pg/test/fixtures/drop_fixtures.sql
@@ -20,3 +20,6 @@ DROP TABLE IF EXISTS observatory.obs_6c1309a64d8f3e6986061f4d1ca7b57743e75e74;
 DROP TABLE IF EXISTS observatory.obs_d39f7fe5959891c8296490d83c22ded31c54af13;
 DROP TABLE IF EXISTS observatory.obs_144e8b4f906885b2e057ac4842644a553ae49c6e;
 DROP TABLE IF EXISTS observatory.obs_c6fb99c47d61289fbb8e561ff7773799d3fcc308;
+
+        DROP TABLE IF EXISTS observatory.obs_meta
+                        

--- a/src/pg/test/sql/40_observatory_utility_test.sql
+++ b/src/pg/test/sql/40_observatory_utility_test.sql
@@ -77,5 +77,3 @@ SELECT cdb_observatory._OBS_StandardizeMeasureName('test 343 %% 2 qqq }}{{}}') =
 
 SELECT cdb_observatory.OBS_DumpVersion()
   IS NOT NULL AS OBS_DumpVersion_notnull;
-
-\i test/fixtures/drop_fixtures.sql

--- a/src/pg/test/sql/40_observatory_utility_test.sql
+++ b/src/pg/test/sql/40_observatory_utility_test.sql
@@ -1,6 +1,8 @@
 \pset format unaligned
 \set ECHO all
 \i test/fixtures/load_fixtures.sql
+SET client_min_messages TO WARNING;
+\set ECHO none
 
 -- OBS_GeomTable
 -- get table with known geometry_id

--- a/src/pg/test/sql/41_observatory_augmentation_test.sql
+++ b/src/pg/test/sql/41_observatory_augmentation_test.sql
@@ -1,4 +1,3 @@
-\i test/fixtures/load_fixtures.sql
 \pset format unaligned
 \set ECHO none
 
@@ -236,5 +235,3 @@ SELECT cdb_observatory.OBS_GetMeasureById(
   'us.census.tiger.block_group',
   '2010 - 2014'
 ) IS NULL As OBS_GetMeasureById_nulls;
-
-\i test/fixtures/drop_fixtures.sql

--- a/src/pg/test/sql/41_observatory_augmentation_test.sql
+++ b/src/pg/test/sql/41_observatory_augmentation_test.sql
@@ -172,7 +172,7 @@ SELECT cdb_observatory.OBS_GetCategory(
 
 -- Poly-based OBS_GetCategory
 SELECT cdb_observatory.OBS_GetCategory(
-  cdb_observatory._TestArea(), 'us.census.spielman_singleton_segments.X10') = 'Low income, mix of minorities' As obs_getcategory_polygon;
+  cdb_observatory._TestArea(), 'us.census.spielman_singleton_segments.X10') = 'Wealthy, urban without Kids' As obs_getcategory_polygon;
 
 -- Point-based OBS_GetPopulation, default normalization (area)
 SELECT (abs(OBS_GetPopulation - 10923.093200390833950) / 10923.093200390833950) < 0.001 As OBS_GetPopulation FROM
@@ -201,7 +201,7 @@ SELECT cdb_observatory.OBS_GetUSCensusCategory(
 
 -- Area-based OBS_GetUSCensusCategory
 SELECT cdb_observatory.OBS_GetUSCensusCategory(
-  cdb_observatory._testarea(), 'Spielman-Singleton Segments: 10 Clusters') = 'Low income, mix of minorities' As OBS_GetUSCensusCategory_polygon;
+  cdb_observatory._testarea(), 'Spielman-Singleton Segments: 10 Clusters') = 'Wealthy, urban without Kids' As OBS_GetUSCensusCategory_polygon;
 
 
 -- OBS_GetMeasureById tests

--- a/src/pg/test/sql/41_observatory_augmentation_test.sql
+++ b/src/pg/test/sql/41_observatory_augmentation_test.sql
@@ -1,5 +1,6 @@
 \pset format unaligned
 \set ECHO none
+SET client_min_messages TO WARNING;
 
 --
 WITH result as(

--- a/src/pg/test/sql/42_observatory_exploration_test.sql
+++ b/src/pg/test/sql/42_observatory_exploration_test.sql
@@ -1,4 +1,3 @@
-\i test/fixtures/load_fixtures.sql
 \pset format unaligned
 
 -- set up variables for use in testing
@@ -32,5 +31,3 @@ SELECT COUNT(*) > 0 AS _OBS_GetAvailableBoundariesExist
 FROM cdb_observatory.OBS_GetAvailableBoundaries(
   cdb_observatory._TestPoint()
 ) AS t(boundary_id, description, time_span, tablename);
-
-\i test/fixtures/drop_fixtures.sql

--- a/src/pg/test/sql/42_observatory_exploration_test.sql
+++ b/src/pg/test/sql/42_observatory_exploration_test.sql
@@ -1,4 +1,6 @@
 \pset format unaligned
+\set ECHO none
+SET client_min_messages TO WARNING;
 
 -- set up variables for use in testing
 

--- a/src/pg/test/sql/44_observatory_geometries_test.sql
+++ b/src/pg/test/sql/44_observatory_geometries_test.sql
@@ -1,5 +1,6 @@
 \pset format unaligned
-\set ECHO all
+\set ECHO none
+SET client_min_messages TO WARNING;
 
 -- set up variables for use in testing
 

--- a/src/pg/test/sql/44_observatory_geometries_test.sql
+++ b/src/pg/test/sql/44_observatory_geometries_test.sql
@@ -1,6 +1,5 @@
 \pset format unaligned
 \set ECHO all
-\i test/fixtures/load_fixtures.sql
 
 -- set up variables for use in testing
 


### PR DESCRIPTION
Resolves #135 

This is built on top of #136, so shares commits with it.  For a clear view of changes, merge #136 first.

In addition to switching to `obs_meta` for `OBS_GetCategory`, this has the pleasant side effect of actual support for `OBS_GetCategory` with a polygon instead of a point.  Previously it returned a value, but an arbitrary one -- now it returns the predominant category in the provided polygon.