### PR TITLE
in this function, it's "measure_id" not "numer_id"

### DIFF
--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -481,7 +481,7 @@ BEGIN
     ELSIF map_type = 'predenominated' THEN
       IF numer_aggregate NOT ILIKE 'sum' THEN
         RAISE EXCEPTION 'Cannot calculate "%" (%) for custom area as it cannot be summed, use ST_PointOnSurface instead',
-                        numer_name, numer_id;
+                        numer_name, measure_id;
       ELSE
         sql = format('WITH _geom AS (SELECT ST_Area(ST_Intersection(%L, geom.%I))
                                           / ST_Area(geom.%I) overlap, geom.%I geom_ref


### PR DESCRIPTION
This was raising an exception which obscured the actual legitimate error in https://github.com/CartoDB/cartodb/issues/9063 .

@ohasselblad LGTM?
