### PR TITLE
return NULL when there is no data for a measure at a geometry according to raster

### DIFF
--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -410,7 +410,12 @@ BEGIN
            ELSE geom
       END;
 
-  raise notice 'Using boundary %', geom_id;
+  IF geom_id IS NULL THEN
+    RAISE NOTICE 'No boundary found for geom';
+    RETURN NULL;
+  ELSE
+    RAISE NOTICE 'Using boundary %', geom_id;
+  END IF;
 
   IF normalize ILIKE 'area' AND numer_aggregate ILIKE 'sum' THEN
     map_type := 'areaNormalized';

--- a/src/pg/test/expected/41_observatory_augmentation_test.out
+++ b/src/pg/test/expected/41_observatory_augmentation_test.out
@@ -66,7 +66,10 @@ t
 obs_getmeasure_bad_geometry
 t
 (1 row)
-obs_getmeasure_null
+obs_getmeasure_null_geometry
+t
+(1 row)
+obs_getmeasure_out_of_bounds_geometry
 t
 (1 row)
 obs_getcategory_point

--- a/src/pg/test/sql/41_observatory_augmentation_test.sql
+++ b/src/pg/test/sql/41_observatory_augmentation_test.sql
@@ -203,10 +203,15 @@ SELECT abs(cdb_observatory.OBS_GetMeasure(
   cdb_observatory._ProblemTestArea(),
   'us.census.acs.B01003001') - 96230.2929825897) / 96230.2929825897 < 0.001 As OBS_GetMeasure_bad_geometry;
 
--- OBS_GetMeasure with NULL Input
+-- OBS_GetMeasure with NULL Input geometry
 SELECT cdb_observatory.OBS_GetMeasure(
   NULL,
-  'us.census.acs.B01003001') IS NULL As OBS_GetMeasure_null;
+  'us.census.acs.B01003001') IS NULL As OBS_GetMeasure_null_geometry;
+
+-- OBS_GetMeasure where there is no data
+SELECT cdb_observatory.OBS_GetMeasure(
+  ST_SetSRID(st_point(0, 0), 4326),
+  'us.census.acs.B01003001') IS NULL As OBS_GetMeasure_out_of_bounds_geometry;
 
 -- Point-based OBS_GetCategory
 SELECT cdb_observatory.OBS_GetCategory(


### PR DESCRIPTION
Fixes #220 