### PR TITLE
Handle mixed geometries

### DIFF
--- a/src/pg/test/expected/41_observatory_augmentation_test.out
+++ b/src/pg/test/expected/41_observatory_augmentation_test.out
@@ -153,6 +153,9 @@ t
 obs_getmeta_suggested_name
 t
 (1 row)
+obs_getmeta_suggested_name_implicit_area
+t
+(1 row)
 obs_getmeta_suggested_name_area
 t
 (1 row)


### PR DESCRIPTION
* Handle mixed geometries (IE one column with ZCTA data, another with tract data) far more efficiently
  - Instead of matching all user geometries to all Observatory geometries in one CTE, we now do one CTE per unique Observatory geometry
* Automatically assign `normalization` as part of `OBS_GetMeta` when it is not specified.