### PR TITLE
Release v1.5.1

### DIFF
--- a/src/pg/test/expected/41_observatory_augmentation_test.out
+++ b/src/pg/test/expected/41_observatory_augmentation_test.out
@@ -153,6 +153,9 @@ t
 obs_getmeta_suggested_name
 t
 (1 row)
+obs_getmeta_suggested_name_implicit_area
+t
+(1 row)
 obs_getmeta_suggested_name_area
 t
 (1 row)


### PR DESCRIPTION
## Request for a new Data observatory extension deploy

I'd like to request a new data observatory extension deploy: dump + extension

## Performance comparison to last deployment

Performance is identical to 1.5.0, except for regression in `OBS_GetCategory`.  However, `OBS_GetCategory` performance is not a priority as it should only be used on one-off requests for data.  Bulk requests should be handled through `OBS_GetData`.

## Dump database id to be deployed

Please put here the dump id to be deployed: `Dump_2017_05_04_f20ee1131c.dump`

## Data Observatory extension PRs included.

  - https://github.com/CartoDB/observatory-extension/pull/285
