### PR TITLE
Return NULL for the affected value and not for all the measurements

### DIFF
--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -760,16 +760,13 @@ BEGIN
               || ') val_' || colid, ', ')
             || '
             FROM _procgeoms_' || Coalesce(geom_tablename || '_' || geom_geomref_colname, api_method) || ' _procgeoms ' ||
-              Coalesce(', ' || String_Agg(DISTINCT
-                  Coalesce('observatory.' || numer_tablename,
-                    'LATERAL (SELECT * FROM cdb_observatory.' || api_method || '(_procgeoms.geom' || Coalesce(', ' ||
+              Coalesce(String_Agg(DISTINCT
+                  Coalesce('LEFT JOIN observatory.' || numer_tablename || ' ON _procgeoms.geomref = observatory.' || numer_tablename || '.' || numer_geomref_colname,
+                    ', LATERAL (SELECT * FROM cdb_observatory.' || api_method || '(_procgeoms.geom' || Coalesce(', ' ||
                         (SELECT STRING_AGG(REPLACE(val::text, '"', ''''), ', ')
                           FROM (SELECT JSON_Array_Elements(api_args) as val) as vals),
                         '') || ')) AS ' || api_method)
-              , ', '), '') ||
-            Coalesce(' WHERE ' || String_Agg(DISTINCT
-              '_procgeoms.geomref = ' || numer_tablename || '.' || numer_geomref_colname, ' AND '
-            ), '') ||
+              , ' '), '') ||
             CASE $3 WHEN True THEN E'\n GROUP BY _procgeoms.id ORDER BY _procgeoms.id '
                     ELSE           E'\n GROUP BY _procgeoms.id, _procgeoms.geomref
                                         ORDER BY _procgeoms.id, _procgeoms.geomref' END


### PR DESCRIPTION
Right now we're doing INNER JOINS when we JOIN the _procgeoms and
the data so we end up with NULL value instead of id, NULL value. We need
to have the id available to make the JOIN at the end of the query and
provide results like this:

```
id |                               data
----+------------------------------------------------------------------
  1 | [{"value" : 858469},{"value" : 73.9397964478},{"value" : 69092}]
  2 | [{"value" : 738774},{"value" : null},{"value" : 2235406}]
```

// @juanignaciosl for awareness