### PR TITLE
Modified the denominated suggested_name to mitigate collisions

### DIFF
--- a/src/pg/sql/41_observatory_augmentation.sql
+++ b/src/pg/sql/41_observatory_augmentation.sql
@@ -249,10 +249,10 @@ BEGIN
           'suggested_name', cdb_observatory.FIRST(
             LOWER(TRIM(BOTH '_' FROM regexp_replace(CASE WHEN numer_id IS NOT NULL
               THEN CASE
-                WHEN normalization ILIKE 'area%%' THEN numer_colname || ' per sq km'
-                WHEN normalization ILIKE 'denom%%' THEN numer_colname || ' rate'
-                ELSE numer_colname
-              END || ' ' || numer_timespan
+                WHEN normalization ILIKE 'area%%' THEN numer_colname || ' per sq km' || ' ' || numer_timespan
+                WHEN normalization ILIKE 'denom%%' THEN numer_colname || ' ' || numer_timespan || ' by ' || denom_colname
+                ELSE numer_colname || ' ' || numer_timespan
+              END
               ELSE geom_name || ' ' || geom_timespan
             END, '[^a-zA-Z0-9]+', '_', 'g')))
           ),

--- a/src/pg/test/sql/41_observatory_augmentation_test.sql
+++ b/src/pg/test/sql/41_observatory_augmentation_test.sql
@@ -416,7 +416,7 @@ SELECT cdb_observatory.OBS_GetMeta(cdb_observatory._TestPoint(),
 -- OBS_GetMeta provides suggested name for simple meta request with denom
 SELECT cdb_observatory.OBS_GetMeta(cdb_observatory._TestPoint(),
   '[{"numer_id": "us.census.acs.B01001002", "normalization": "denom"}]'
-)->0->>'suggested_name' = 'male_pop_rate_2010_2014' obs_getmeta_suggested_name_denom;
+)->0->>'suggested_name' = 'male_pop_2010_2014_by_total_pop' obs_getmeta_suggested_name_denom;
 
 -- OBS_GetData/OBS_GetMeta by id with empty list/null
 WITH data AS (SELECT * FROM cdb_observatory.OBS_GetData(ARRAY[]::TEXT[], null))


### PR DESCRIPTION
Modified the `suggested_name` for denominator normalizations to mitigate collisions between column names: `numerator_timespan_by_denominator`.

This mitigates the problem but doesn't completely solve it because the `suggested_name` can easily reach the 63 character limitation for the column names.

Fixes https://github.com/CartoDB/cartoframes/issues/323