### PR TITLE
Remove new fields not used to simplify deploy process

### DIFF
--- a/release/observatory--1.9.0.sql
+++ b/release/observatory--1.9.0.sql
@@ -1830,9 +1830,7 @@ CREATE OR REPLACE FUNCTION cdb_observatory.OBS_GetAvailableTimespans(
   timespan_tags JSONB,
   valid_numer BOOLEAN,
   valid_denom BOOLEAN,
-  valid_geom BOOLEAN,
-  timespan_alias TEXT,
-  timespan_range DATERANGE
+  valid_geom BOOLEAN
 ) AS $$
 DECLARE
   geom_clause TEXT;
@@ -1861,9 +1859,7 @@ BEGIN
            NULL::JSONB timespan_tags,
     COALESCE($1 = ANY(numers), false) valid_numer,
     COALESCE($2 = ANY(denoms), false) valid_denom,
-    COALESCE($3 = ANY(geoms), false) valid_geom_id,
-           timespan_alias::TEXT,
-           timespan_range::DATERANGE
+    COALESCE($3 = ANY(geoms), false) valid_geom_id
     FROM observatory.obs_meta_timespan
     WHERE %s (timespan_tags ?& $4 OR CARDINALITY($4) = 0)
   $string$, geom_clause)

--- a/src/pg/sql/42_observatory_exploration.sql
+++ b/src/pg/sql/42_observatory_exploration.sql
@@ -424,9 +424,7 @@ CREATE OR REPLACE FUNCTION cdb_observatory.OBS_GetAvailableTimespans(
   timespan_tags JSONB,
   valid_numer BOOLEAN,
   valid_denom BOOLEAN,
-  valid_geom BOOLEAN,
-  timespan_alias TEXT,
-  timespan_range DATERANGE
+  valid_geom BOOLEAN
 ) AS $$
 DECLARE
   geom_clause TEXT;
@@ -455,9 +453,7 @@ BEGIN
            NULL::JSONB timespan_tags,
     COALESCE($1 = ANY(numers), false) valid_numer,
     COALESCE($2 = ANY(denoms), false) valid_denom,
-    COALESCE($3 = ANY(geoms), false) valid_geom_id,
-           timespan_alias::TEXT,
-           timespan_range::DATERANGE
+    COALESCE($3 = ANY(geoms), false) valid_geom_id
     FROM observatory.obs_meta_timespan
     WHERE %s (timespan_tags ?& $4 OR CARDINALITY($4) = 0)
   $string$, geom_clause)


### PR DESCRIPTION
We have two options for this change:

a) Go with the new fields which imply to deploy [dataservices](https://github.com/CartoDB/dataservices-api/pull/493) and a non-graceful deploy because we have some time between the new DS version is deployed and we change the config to point to the new  obs dump. Also this leads to put the dump directly into production

b) Remove this new fields, which are not going to be used at the moment and make only a release for observatory.

I've made the two PR