### PR TITLE
Added cache for OBS_GetMeta function results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
 
 before_install:
   - sudo bash $TRAVIS_BUILD_DIR/scripts/ci/install_postgres.sh
+  - sudo make clean-all
 
 install:
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
 
 matrix:
   include:
-    - env: PGSQL_VERSION=9.5 POSTGIS_VERSION=2.2
     - env: PGSQL_VERSION=9.6 POSTGIS_VERSION=2.3
     - env: PGSQL_VERSION=10 POSTGIS_VERSION=2.4
 

--- a/scripts/ci/install_postgres.sh
+++ b/scripts/ci/install_postgres.sh
@@ -32,7 +32,7 @@ apt-get -y install postgresql-${PGSQL_VERSION} postgresql-${PGSQL_VERSION}-postg
 # Configure it to accept local connections from postgres
 echo -e "# TYPE  DATABASE        USER            ADDRESS                 METHOD \nlocal   all             postgres                                trust\nlocal   all             all                                     trust\nhost    all             all             127.0.0.1/32            trust" > /etc/postgresql/${PGSQL_VERSION}/main/pg_hba.conf
 
-psql -c  "CREATE LANGUAGE plpythonu;"
+psql -U postgres -c  "CREATE LANGUAGE plpythonu;"
 
 # Restart PostgreSQL
 /etc/init.d/postgresql restart ${PGSQL_VERSION}

--- a/scripts/ci/install_postgres.sh
+++ b/scripts/ci/install_postgres.sh
@@ -32,8 +32,6 @@ apt-get -y install postgresql-${PGSQL_VERSION} postgresql-${PGSQL_VERSION}-postg
 # Configure it to accept local connections from postgres
 echo -e "# TYPE  DATABASE        USER            ADDRESS                 METHOD \nlocal   all             postgres                                trust\nlocal   all             all                                     trust\nhost    all             all             127.0.0.1/32            trust" > /etc/postgresql/${PGSQL_VERSION}/main/pg_hba.conf
 
-psql -U postgres -c  "CREATE LANGUAGE plpythonu;"
-
 # Restart PostgreSQL
 /etc/init.d/postgresql restart ${PGSQL_VERSION}
 

--- a/scripts/ci/install_postgres.sh
+++ b/scripts/ci/install_postgres.sh
@@ -27,7 +27,7 @@ done
 apt-get -y autoremove
 
 # Install PostgreSQL
-apt-get -y install postgresql-${PGSQL_VERSION} postgresql-${PGSQL_VERSION}-postgis-${POSTGIS_VERSION} postgresql-server-dev-${PGSQL_VERSION}
+apt-get -y install postgresql-${PGSQL_VERSION} postgresql-${PGSQL_VERSION}-postgis-${POSTGIS_VERSION} postgresql-server-dev-${PGSQL_VERSION} postgresql-plpython-${PGSQL_VERSION}
 
 # Configure it to accept local connections from postgres
 echo -e "# TYPE  DATABASE        USER            ADDRESS                 METHOD \nlocal   all             postgres                                trust\nlocal   all             all                                     trust\nhost    all             all             127.0.0.1/32            trust" > /etc/postgresql/${PGSQL_VERSION}/main/pg_hba.conf

--- a/scripts/ci/install_postgres.sh
+++ b/scripts/ci/install_postgres.sh
@@ -32,6 +32,8 @@ apt-get -y install postgresql-${PGSQL_VERSION} postgresql-${PGSQL_VERSION}-postg
 # Configure it to accept local connections from postgres
 echo -e "# TYPE  DATABASE        USER            ADDRESS                 METHOD \nlocal   all             postgres                                trust\nlocal   all             all                                     trust\nhost    all             all             127.0.0.1/32            trust" > /etc/postgresql/${PGSQL_VERSION}/main/pg_hba.conf
 
+psql -c  "CREATE LANGUAGE plpythonu;"
+
 # Restart PostgreSQL
 /etc/init.d/postgresql restart ${PGSQL_VERSION}
 

--- a/src/pg/test/expected/01_install_test.out
+++ b/src/pg/test/expected/01_install_test.out
@@ -1,5 +1,6 @@
 -- Install dependencies
 CREATE EXTENSION postgis;
+CREATE LANGUAGE plpythonu;
 -- Install the extension
 CREATE EXTENSION observatory VERSION 'dev';
 \i test/fixtures/load_fixtures.sql

--- a/src/pg/test/sql/01_install_test.sql
+++ b/src/pg/test/sql/01_install_test.sql
@@ -1,5 +1,6 @@
 -- Install dependencies
 CREATE EXTENSION postgis;
+CREATE LANGUAGE plpythonu;
 
 -- Install the extension
 CREATE EXTENSION observatory VERSION 'dev';


### PR DESCRIPTION
Added table to cache `OBS_GetMeta` function results and improve performance.
Although the `OBS_GetMeta` function receives the `geom` as a parameter, the cache is maintained for each zoom level.

Closes https://github.com/CartoDB/observatory-extension/issues/336