### PR TITLE
Support for PG11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,11 @@
-language: c
-group: travis_stable
+language: generic
 sudo: required
-
 env:
-  global:
-    - PAGER=cat
-
-matrix:
-  include:
-    - env: PGSQL_VERSION=9.6 POSTGIS_VERSION=2.3
-    - env: PGSQL_VERSION=10 POSTGIS_VERSION=2.4
-
-before_install:
-  - sudo bash $TRAVIS_BUILD_DIR/scripts/ci/install_postgres.sh
-  - sudo make clean-all
-
-install:
-  - sudo make install
-
+  matrix:
+    - DOCKER_IMAGE=carto/postgresql10:latest
+    - DOCKER_IMAGE=carto/postgresql11:latest
+services:
+  - docker
+before_install: docker pull ${DOCKER_IMAGE}
 script:
-  - cd src/pg
-  - make test || { cat $TRAVIS_BUILD_DIR/src/pg/test/regression.diffs; false; }
+  - ./scripts/ci/docker-test.sh ${DOCKER_IMAGE}

--- a/scripts/ci/docker-test.sh
+++ b/scripts/ci/docker-test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker run -e PGHOST=localhost -e PGPORT=5432 -v `pwd`:/srv --entrypoint="/bin/bash" ${1} /srv/scripts/ci/run_tests_docker.sh && \
+    docker ps --filter status=dead --filter status=exited -aq | xargs docker rm -v

--- a/scripts/ci/run_tests_docker.sh
+++ b/scripts/ci/run_tests_docker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+/etc/init.d/postgresql start
+
+cd /srv
+
+make clean-all
+make install
+
+cd /srv/src/pg
+
+make test || { cat /srv/src/pg/test/regression.diffs; false; }

--- a/src/pg/test/expected/42_observatory_exploration_test.out
+++ b/src/pg/test/expected/42_observatory_exploration_test.out
@@ -246,7 +246,7 @@ us.census.tiger.county|295
 column_id|_obs_geometryscores_numgeoms_2500km_buffer
 us.census.tiger.block_group|165852
 us.census.tiger.census_tract|55283
-us.census.tiger.zcta5|27046
+us.census.tiger.zcta5|26529
 us.census.tiger.county|2551
 (4 rows)
 _obs_geometryscores_500km_buffer_50_geoms


### PR DESCRIPTION
- Start using Docker to test in TravisCI
- Support for PG10 and PG11 and remove support for old versions